### PR TITLE
#36 Add two additional tests for template error handling. Add error handling code

### DIFF
--- a/techs/bem-xjst.js
+++ b/techs/bem-xjst.js
@@ -58,7 +58,11 @@ module.exports = require('enb/lib/build-flow').create()
                         includeVow: this._includeVow,
                         modulesDeps: this._modulesDeps
                     });
-                }, this);
+                }, this)
+                .fail(function (error) {
+                    bemxjstProcessor.dispose();
+                    throw error;
+                });
         }
     })
     .createTech();

--- a/test/techs/bemhtml/bemhtml.test.js
+++ b/test/techs/bemhtml/bemhtml.test.js
@@ -134,6 +134,28 @@ describe('bemhtml', function () {
             });
         });
     });
+
+    describe('handle template errors', function () {
+        it('must return rejected promise for template errors (development mode)', function () {
+            var templates = ['block("bla")tag()("a")'],
+                options = { devMode: true };
+
+            return build(templates, options)
+                .fail(function (error) {
+                    error.message.must.be.equal('Unexpected identifier');
+                });
+        });
+
+        it('must return rejected promise for template errors (production mode)', function () {
+            var templates = ['block("bla")tag()("a")'],
+                options = { devMode: false };
+
+            return build(templates, options)
+                .fail(function (error) {
+                    error.message.must.be.equal('Line 486: Unexpected identifier');
+                });
+        });
+    });
 });
 
 function build(templates, options) {

--- a/test/techs/bemhtml/bemhtml.test.js
+++ b/test/techs/bemhtml/bemhtml.test.js
@@ -136,23 +136,23 @@ describe('bemhtml', function () {
     });
 
     describe('handle template errors', function () {
-        it('must return rejected promise for template errors (development mode)', function () {
+        it('must return rejected promise for template with syntax errors (development mode)', function () {
             var templates = ['block("bla")tag()("a")'],
                 options = { devMode: true };
 
             return build(templates, options)
                 .fail(function (error) {
-                    error.message.must.be.equal('Unexpected identifier');
+                    error.message.must.be.include('Unexpected identifier');
                 });
         });
 
-        it('must return rejected promise for template errors (production mode)', function () {
+        it('must return rejected promise for template with syntax errors (production mode)', function () {
             var templates = ['block("bla")tag()("a")'],
                 options = { devMode: false };
 
             return build(templates, options)
                 .fail(function (error) {
-                    error.message.must.be.equal('Line 486: Unexpected identifier');
+                    error.message.must.be.include('Line 486: Unexpected identifier');
                 });
         });
     });


### PR DESCRIPTION
Add throw error declaration on bemxjst processor promise rejection. Also bemxjstProcessor.dispose() call was added for this case.

Resolved #36 

@blond @sipayRT 
Please review it